### PR TITLE
remove ports from csrf_trusted_origins

### DIFF
--- a/smse_onboarding_main_project/smse_onboarding/settings.py
+++ b/smse_onboarding_main_project/smse_onboarding/settings.py
@@ -92,13 +92,13 @@ TEMPLATES = [
 ]
 
 CSRF_TRUSTED_ORIGINS = [
-    'https://smse-onboarding.dedyn.io:8080',
-    'http://smse-onboarding.dedyn.io:8000',
+    #'https://smse-onboarding.dedyn.io:8080',
+    #'http://smse-onboarding.dedyn.io:8000',
     'http://smse-onboarding.dedyn.io',
     'http://localhost:8000',
 ]
 
-CSRF_COOKIE_DOMAIN = [None, 'smse-onboarding.dedyn.io']
+CSRF_COOKIE_DOMAIN = 'smse-onboarding.dedyn.io'
 
 WSGI_APPLICATION = 'smse_onboarding.wsgi.application'
 


### PR DESCRIPTION
# Overview

**Type of Change:** Bug Fix

**Summary:** Had an issue that when logging out and trying to switch to another dashboard, the page wouldnt load and there was a csrf error. I think its because when we added the new csrf trusted origins we should have also removed the version with the ports from csrf_trusted_origins in settings. I  think this is what Dr Sat said we should have done but we forgot to remove the ports . Not sure if this works yet until it is pulled into the main. 
