### PR TITLE
added django to allowed hosts in settings & fixed css mistake

### DIFF
--- a/smse_onboarding_main_project/dashboard/templates/dashboard/new_hire/components/status_card.html
+++ b/smse_onboarding_main_project/dashboard/templates/dashboard/new_hire/components/status_card.html
@@ -102,7 +102,7 @@
 }
 
 .prof-email {
-    font-weight: 2rem
+    font-weight: 600;
     font-size: 1.2rem;
 }
 

--- a/smse_onboarding_main_project/smse_onboarding/settings.py
+++ b/smse_onboarding_main_project/smse_onboarding/settings.py
@@ -33,6 +33,7 @@ ALLOWED_HOSTS = [
     'localhost',
     '127.0.0.1',
     '0.0.0.0',
+    'django',  # Add this for Docker container hostname
 ]
 
 


### PR DESCRIPTION
# Overview

**Type of Change:** Bug Fix

**Summary:** _TODO: when trying to run the app through production in digitial ocean, was getting error that said container was unhealthy. The logs said something about adding django to the allowed hosts so im testing if that works 


